### PR TITLE
Attempt to fix problem when mediaList is passed back to Stack.Scan 

### DIFF
--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -653,13 +653,15 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                             )
                         )
                         episode_split = [
-                            str(episode[i : i + 2])  # noqa: E203
-                            for i in range(0, len(episode), 2)
+                            str(episode[x : x + 2])  # noqa: E203
+                            for x in range(0, len(episode), 2)
                         ]
-                        tv_show.released_at = "{}-{}-{}".format(
-                            episode_split[0],
-                            episode_split[1],
-                            episode_split[2],
+                        tv_show.released_at = str(
+                            "{}-{}-{}".format(
+                                episode_split[0],
+                                episode_split[1],
+                                episode_split[2],
+                            )
                         ).encode("UTF-8")
                         tv_show.parts.append(i)
                         Log.info(


### PR DESCRIPTION
Attempt to fix problem when mediaList is passed back to Stack.Scan and is getting an AttributeError.

Note: `i` was overwriting `i` from the parent loop.